### PR TITLE
Fix mrb_parse_string

### DIFF
--- a/example/runner.c
+++ b/example/runner.c
@@ -55,7 +55,7 @@ int main(int argc, char **argv)
   mrb_uv_init(mrb);
   mrb_http_init(mrb);
 
-  struct mrb_parser_state* st = mrb_parse_string(mrb, code);
+  struct mrb_parser_state* st = mrb_parse_string(mrb, code, NULL);
   free(code);
 
   int n = mrb_generate_code(mrb, st->tree);


### PR DESCRIPTION
mrb_parse_\* need mrb_context.

mrb_parse_stringには引数にmrb_contextが必要なったようなので、コンパイルエラー修正のために、引数NULLを渡すように変更しておきました。
