### PR TITLE
Fix mrb_http_request_port check

### DIFF
--- a/src/mrb_http.c
+++ b/src/mrb_http.c
@@ -348,7 +348,7 @@ mrb_http_request_port(mrb_state *mrb, mrb_value self)
     return mrb_fixnum_value(context->handle.port);
   }
   mrb_value schema = mrb_http_request_schema(mrb, self);
-  if (!mrb_nil_p(schema) && !strncmp("https", (char*) RSTRING_PTR(schema), RSTRING_LEN(schema))) {
+  if (!mrb_nil_p(schema) && !strncmp("https", (char*) RSTRING_PTR(schema), RSTRING_LEN(schema)) && strlen("https") == RSTRING_LEN(schema)) {
     return mrb_fixnum_value(443);
   }
   return mrb_fixnum_value(80);
@@ -497,7 +497,7 @@ mrb_http_url_port(mrb_state *mrb, mrb_value self)
     return mrb_fixnum_value(context->port);
   }
   mrb_value schema = mrb_http_url_schema(mrb, self);
-  if (!mrb_nil_p(schema) && !strncmp("https", (char*) RSTRING_PTR(schema), RSTRING_LEN(schema))) {
+  if (!mrb_nil_p(schema) && !strncmp("https", (char*) RSTRING_PTR(schema), RSTRING_LEN(schema)) && strlen("https") == RSTRING_LEN(schema)) {
     return mrb_fixnum_value(443);
   }
   return mrb_fixnum_value(80);


### PR DESCRIPTION
mrb_http_request_portにおけるschemeチェックが、strcncmpでの"https"文字列とschemeの比較だと、schemeがhttpでもhttpsでもそれぞれの文字列のバイトの範囲内で必ずマッチしてしまうため、ポート番号を指定していないとhttpでも443を返していました。
それを修正したので確認をお願いします。
