### PR TITLE
change test executer to rake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,8 @@ script:
       tar xf mruby-$MRUBY_VERSION.tar.gz;
     fi'
   - cd mruby-$MRUBY_VERSION
-  - ./minirake -v all test
+  - 'if [ "$MRUBY_VERSION" = "master" ] ; then
+      rake -m test:build && rake test:run
+    else
+      ./minirake -v all test
+    fi'


### PR DESCRIPTION
Hi @mattn!
I appreciate for your daily oss contribution.

This PR is change test executer each mruby versions.
[It is refer from mruby master branch.](https://github.com/mruby/mruby/blob/master/.github/workflows/build.yml#L19)

Please consider merge!
Lastly, If you have a time, could you check my colleagues Pull Request
https://github.com/mattn/mruby-http/pull/16

Thanks.

Japanese:
いつもいろいろなOSSに貢献していただきありがとうございます。
mruby-httpのCIが落ちているようなので、mruby3はrakeを利用しているようなので、そちらに変更しました。

合わせて、同僚が、mruby-httpを利用したときに `Transfer-Encoding: chunked` でうまく動作しない問題があったのでそれを修正するPRを出していたので、そちらについても確認いただけると助かります！