### PR TITLE
Add GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: Build & Test
+on: [push, pull_request]
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        parallelism: [2]
+        mruby_version: ["master", "1.4.0"]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download mruby source
+        env:
+          MRUBY_VERSION: ${{ matrix.mruby_version }}
+        run: |
+          if [ "$MRUBY_VERSION" = "master" ] ; then
+            git clone --depth 1 "https://github.com/mruby/mruby.git" mruby-$MRUBY_VERSION;
+          else
+            curl -L "https://github.com/mruby/mruby/archive/$MRUBY_VERSION.tar.gz" > mruby-$MRUBY_VERSION.tar.gz;
+            tar xf mruby-$MRUBY_VERSION.tar.gz;
+          fi
+      - name: Build and test
+        env:
+          MRUBY_VERSION: ${{ matrix.mruby_version }}
+        run: |
+          cd mruby-$MRUBY_VERSION
+          if [ "$MRUBY_VERSION" = "master" ] ; then
+            rake -m test:build && rake test:run
+          else
+            ./minirake -v all test
+          fi


### PR DESCRIPTION
Sorry Again @mattn.
I don't think travis.ci will be used so aggressively in the future, so if you want to move to GitHub Actions? This PR makes it available in parallel!

Thanks!